### PR TITLE
TSConfig: Exclude "dist" directory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "astro/tsconfigs/strictest"
+  "extends": "astro/tsconfigs/strictest",
+  "exclude": ["./dist/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "astro/tsconfigs/strictest",
-  "exclude": ["./dist/**/*"]
+  "exclude": ["./dist"]
 }


### PR DESCRIPTION
When running subsequent builds locally, the log gets some warnings from `dist` directory, which isn't excluded. This small change fixes it