### PR TITLE
E2E: Remove color scheme "no-preference" test

### DIFF
--- a/tests-e2e/theme.spec.ts
+++ b/tests-e2e/theme.spec.ts
@@ -1,15 +1,5 @@
 import {test, expect, type Page} from '@playwright/test';
 
-test('uses light theme on first visit (if no preference)', async ({
-  page,
-  browserName,
-}) => {
-  test.skip(browserName === 'webkit'); // If macOS color preference is set to dark, it still falls back to it in WebKit browser(s)
-  await page.emulateMedia({colorScheme: 'no-preference'});
-  await page.goto('/');
-  await expectThemeLight({page});
-});
-
 test('uses device theme preference on first visit (light)', async ({page}) => {
   await page.emulateMedia({colorScheme: 'light'});
   await page.goto('/');


### PR DESCRIPTION
Follow up on https://github.com/microsoft/playwright/issues/32862.
Eventually, `no-preference` color scheme option will be removed in the next version(s) of Playwright.